### PR TITLE
Update aria2.conf

### DIFF
--- a/aria2.conf
+++ b/aria2.conf
@@ -384,6 +384,9 @@ quiet=false
 # 下载进度摘要输出间隔时间（秒），0 为禁止输出。默认：60
 summary-interval=0
 
+# 关闭控制台进度条输出，避免日志里面打印大量空行
+show-console-readout=false
+
 
 ## 增强扩展设置(非官方) ##
 


### PR DESCRIPTION
Fix [72](https://github.com/P3TERX/Aria2-Pro-Docker/issues/72)，关闭console readout即控制台打印的进度条，避免日志里大量空白行